### PR TITLE
Escape URL in quotes

### DIFF
--- a/lib/har-to-curl.js
+++ b/lib/har-to-curl.js
@@ -79,5 +79,6 @@ harToCurl.fromEntry = function(entry) {
 		command += ' -d "' + entry.request.postData.text + '"';
 	}
 
-	return command + ' ' + entry.request.url;
+        var quoted_url = '"'+ entry.request.url.replace('\\','\\\\')+'"';
+	return command + ' ' + quoted_url;
 };


### PR DESCRIPTION
The rest of fields are not even escaped which may result in remote code execution when executing the generated curl lines. This patch makes the har-to-curl at least work. But the rest of fields should be properly validated and filtered too.
