### PR TITLE
npm: Fix the license field and add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 build/
+node_modules/

--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
 			"email": "m@m.cg"
 		}
 	],
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://mattcg.mit-license.org/"
-		}
-	],
+	"license": "MIT",
 	"keywords": [
 		"curl",
 		"har",


### PR DESCRIPTION
npm showed a warning when running `npm install`:
`npm WARN EPACKAGEJSON har-to-curl@0.4.1 No license field.`

The `licenses` has been deprecated and replaced by `license`.

The `node_modules` directory, generated by `npm install`, should also be gitignored.
