### PR TITLE
Support postData in form of params

### DIFF
--- a/lib/har-to-curl.js
+++ b/lib/har-to-curl.js
@@ -76,7 +76,14 @@ harToCurl.fromEntry = function(entry) {
 	}).join('');
 
 	if (entry.request.postData) {
-		command += ' -d "' + entry.request.postData.text + '"';
+		var text = entry.request.postData.text;
+		if ( text === '') {
+			// TODO: support param.fileName, param.contentType, param.comment
+			text = entry.request.postData.params.map(function(param) {
+				return param.name + '=' + param.value ;
+			}).join('&');
+		}
+		command += ' -d "' + text + '"';
 	}
 
 	return command + ' ' + entry.request.url;


### PR DESCRIPTION
Only name and value fields of param are supported.
See http://www.softwareishard.com/blog/har-12-spec/#postData and
http://www.softwareishard.com/blog/har-12-spec/#params

Partially fixes https://github.com/mattcg/har-to-curl/issues/6